### PR TITLE
Fix Jaxon Smith-Njigba position

### DIFF
--- a/matchup_data/convert_html_to_csv.py
+++ b/matchup_data/convert_html_to_csv.py
@@ -51,7 +51,7 @@ def convert_league_matchup_table_to_csv():
 def extract_position(text):
     '''function that extracts the position from Yahoo player html'''
     try:
-        text = text.split("-")[1].split(" ")[1]
+        text = text.split(" - ")[1].split(" ")[0]
     except:
         pass
     return text

--- a/matchup_data/week2/matchup_5.csv
+++ b/matchup_data/week2/matchup_5.csv
@@ -6,7 +6,7 @@
 4,J. FordCle ,RB,7.4,RB,26.1,RB,J. DobbinsLAC 
 5,C. ParkinsonLAR ,TE,2.2,TE,4.6,TE,I. LikelyBal 
 6,D. SmithPhi ,WR,20.6,W/R/T,5.1,WR,M. Pittman Jr.Ind 
-7,J. ConnerAri ,RB,22.4,W/R/T,26.7,,J. Smith
+7,J. ConnerAri ,RB,22.4,W/R/T,26.7,WR,J. Smith
 8,SeattleSea ,DEF,6.0,DEF,18.0,DEF,BuffaloBuf 
 9,nan,,159.94,Total,123.66,,nan
 10,K. Walker IIISea ,RB,0.0,BN,11.60,RB,C. HubbardCar 


### PR DESCRIPTION
Fixed a bug where Smith's position wasn't properly being extracted. This was happening because he has a hyphen in his name "-", which was the string we were originally splitting from to get the position. I updated the string to have a space on each side, to make sure it isn't a part of a name and instead the gap between the name and position. 

`J. Smith-NjigbaSea - WR Final W 23-20 @ NE  Player Note`