### PR TITLE
Removed team abbreviations from the end of player names

### DIFF
--- a/matchup_data/convert_html_to_csv.py
+++ b/matchup_data/convert_html_to_csv.py
@@ -1,6 +1,7 @@
 from bs4 import BeautifulSoup
 import pandas as pd
 import os
+from utils import team_abbrev
 
 # User Input
 WEEK = 2
@@ -56,13 +57,25 @@ def extract_position(text):
         pass
     return text
 
+def extract_player_name(text):
+    text = str(text).split("-")[0].strip()
+    if text[-2:].upper() in team_abbrev:
+        player = text[:-2]
+    elif text[-3:].upper() in team_abbrev:
+        player = text[:-3]
+    else:
+        player = text
+    return player
+        
+
+
 def clean_matchup_df(df):
     '''cleans up the Yahoo html table by removing unneeded columns and linting player data'''
     df.drop(['Stats', 'Stats.1'], axis=1, inplace=True)
     df["Position"] = df["Player"].apply(lambda x: extract_position(x))
-    df["Player"] = df["Player"].apply(lambda x: str(x).split("-")[0])
+    df["Player"] = df["Player"].apply(lambda x: extract_player_name(x))
     df["Position.1"] = df["Player.1"].apply(lambda x: extract_position(x))
-    df["Player.1"] = df["Player.1"].apply(lambda x: str(x).split("-")[0])
+    df["Player.1"] = df["Player.1"].apply(lambda x: extract_player_name(x))
     return df
 
 def convert_detailed_matchup_to_csv():

--- a/matchup_data/utils.py
+++ b/matchup_data/utils.py
@@ -1,0 +1,1 @@
+team_abbrev = ["ARI", "ATL", "BAL", "BUF", "CAR", "CHI", "CIN", "CLE", "DAL", "DEN", "DET", "GB", "HOU", "IND", "JAX", "KC", "MIA", "MIN", "NE", "NO", "NYG", "NYJ", "LV", "PHI", "PIT", "LAC", "SF", "SEA", "LAR", "TB", "TEN", "WAS"]

--- a/matchup_data/week2/matchup_1.csv
+++ b/matchup_data/week2/matchup_1.csv
@@ -1,21 +1,21 @@
 ,EZ DubZ,Position,Fan Pts,Roster Pos,Fan Pts.1,Position.1,Pitter Patter
-0,J. BurrowCin ,QB,17.22,QB,9.76,QB,J. AllenBuf 
-1,T. HillMia ,WR,6.6,WR,34.9,WR,D. MetcalfSea 
-2,D. Samuel Sr.SF ,WR,21.0,WR,10.2,WR,G. WilsonNYJ 
-3,R. WhiteTB ,RB,3.3,RB,17.6,RB,J. GibbsDet 
-4,I. PachecoKC ,RB,16.1,RB,29.5,RB,D. AchaneMia 
-5,G. KittleSF ,TE,20.6,TE,0.0,TE,E. EngramJax 
-6,J. WilliamsDet ,WR,14.4,W/R/T,27.7,WR,C. RidleyTen 
-7,J. MasonSF ,RB,20.4,W/R/T,0.0,WR,C. WatsonGB 
-8,San FranciscoSF ,DEF,8.0,DEF,11.0,DEF,New YorkNYJ 
+0,J. Burrow,QB,17.22,QB,9.76,QB,J. Allen
+1,T. Hill,WR,6.6,WR,34.9,WR,D. Metcalf
+2,D. Samuel Sr.,WR,21.0,WR,10.2,WR,G. Wilson
+3,R. White,RB,3.3,RB,17.6,RB,J. Gibbs
+4,I. Pacheco,RB,16.1,RB,29.5,RB,D. Achane
+5,G. Kittle,TE,20.6,TE,0.0,TE,E. Engram
+6,J. Williams,WR,14.4,W/R/T,27.7,WR,C. Ridley
+7,J. Mason,RB,20.4,W/R/T,0.0,WR,C. Watson
+8,San Francisco,DEF,8.0,DEF,11.0,DEF,New York
 9,nan,,127.62,Total,140.66,,nan
-10,L. McConkeyLAC ,WR,4.6,BN,0.0,WR,P. NacuaLAR 
-11,D. SwiftChi ,RB,8.2,BN,3.9,WR,J. PalmerLAC 
-12,M. WilliamsNYJ ,WR,2.9,BN,8.5,QB,T. TagovailoaMia 
-13,J. PolkNE ,WR,9.2,BN,0.4,RB,J. WrightMia 
-14,M. WilsonAri ,WR,5.1,BN,2.0,TE,T. ConklinNYJ 
-15,T. BigsbyJax ,RB,0.0,BN,3.9,RB,J. WilliamsNO 
-16,D. RobinsonLAR ,WR,7.0,BN,2.8,RB,M. LloydGB 
-17,B. MayfieldTB ,QB,22.8,BN,16.6,WR,A. PierceInd 
-18,R. PearsallSF ,WR,0.0,IR,0.0,RB,N. ChubbCle 
+10,L. McConkey,WR,4.6,BN,0.0,WR,P. Nacua
+11,D. Swift,RB,8.2,BN,3.9,WR,J. Palmer
+12,M. Williams,WR,2.9,BN,8.5,QB,T. Tagovailoa
+13,J. Polk,WR,9.2,BN,0.4,RB,J. Wright
+14,M. Wilson,WR,5.1,BN,2.0,TE,T. Conklin
+15,T. Bigsby,RB,0.0,BN,3.9,RB,J. Williams
+16,D. Robinson,WR,7.0,BN,2.8,RB,M. Lloyd
+17,B. Mayfield,QB,22.8,BN,16.6,WR,A. Pierce
+18,R. Pearsall,WR,0.0,IR,0.0,RB,N. Chubb
 19,nan,,59.8,Total,38.1,,nan

--- a/matchup_data/week2/matchup_2.csv
+++ b/matchup_data/week2/matchup_2.csv
@@ -1,21 +1,21 @@
 ,Im and the Gems,Position,Fan Pts,Roster Pos,Fan Pts.1,Position.1,Miles Long
-0,J. FieldsPit ,QB,11.38,QB,17.96,QB,B. PurdySF 
-1,A. St. BrownDet ,WR,25.9,WR,8.5,WR,J. WaddleMia 
-2,C. KuppLAR ,WR,7.7,WR,30.5,WR,N. CollinsHou 
-3,A. JonesMin ,RB,9.8,RB,16.6,RB,D. HenryBal 
-4,K. WilliamsLAR ,RB,15.2,RB,14.8,RB,T. Etienne Jr.Jax 
-5,F. MoreauNO ,TE,0.0,TE,9.1,TE,M. AndrewsBal 
-6,R. RiceKC ,WR,21.5,W/R/T,8.2,WR,T. McLaurinWas 
-7,K. ShakirBuf ,WR,10.6,W/R/T,18.8,TE,B. BowersLV 
-8,PhiladelphiaPhi ,DEF,1.0,DEF,11.0,DEF,Kansas CityKC 
+0,J. Fields,QB,11.38,QB,17.96,QB,B. Purdy
+1,A. St. Brown,WR,25.9,WR,8.5,WR,J. Waddle
+2,C. Kupp,WR,7.7,WR,30.5,WR,N. Collins
+3,A. Jones,RB,9.8,RB,16.6,RB,D. Henry
+4,K. Williams,RB,15.2,RB,14.8,RB,T. Etienne Jr.
+5,F. Moreau,TE,0.0,TE,9.1,TE,M. Andrews
+6,R. Rice,WR,21.5,W/R/T,8.2,WR,T. McLaurin
+7,K. Shakir,WR,10.6,W/R/T,18.8,TE,B. Bowers
+8,Philadelphia,DEF,1.0,DEF,11.0,DEF,Kansas City
 9,nan,,103.08,Total,135.46,,nan
-10,J. FergusonDal ,TE,0.00,BN,4.5,WR,D. JohnsonCar 
-11,W. LevisTen ,QB,15.48,BN,6.8,RB,Z. WhiteLV 
-12,J. LoveGB ,QB,0.00,BN,3.1,WR,A. LazardNYJ 
-13,T. HigginsCin ,WR,0.00,BN,8.1,RB,J. WarrenPit 
-14,J. WilliamsDen ,RB,11.50,BN,5.9,RB,G. EdwardsLAC 
-15,Z. CharbonnetSea ,RB,17.90,BN,14.7,WR,A. IosivasCin 
-16,J. McMillanTB ,WR,3.10,BN,0.2,RB,T. Tracy Jr.NYG 
-17,B. AllenNYJ ,RB,19.60,BN,10.0,DEF,ClevelandCle 
-18,(Empty),(Empty),â,IR,0.0,RB,K. MitchellBal 
+10,J. Ferguson,TE,0.00,BN,4.5,WR,D. Johnson
+11,W. Levis,QB,15.48,BN,6.8,RB,Z. White
+12,J. Love,QB,0.00,BN,3.1,WR,A. Lazard
+13,T. Higgins,WR,0.00,BN,8.1,RB,J. Warren
+14,J. Williams,RB,11.50,BN,5.9,RB,G. Edwards
+15,Z. Charbonnet,RB,17.90,BN,14.7,WR,A. Iosivas
+16,J. McMillan,WR,3.10,BN,0.2,RB,T. Tracy Jr.
+17,B. Allen,RB,19.60,BN,10.0,DEF,Cleveland
+18,(Empty),(Empty),â,IR,0.0,RB,K. Mitchell
 19,nan,,67.58,Total,53.3,,nan

--- a/matchup_data/week2/matchup_3.csv
+++ b/matchup_data/week2/matchup_3.csv
@@ -1,20 +1,20 @@
 ,Jon Gruden,Position,Fan Pts,Roster Pos,Fan Pts.1,Position.1,ELC3
-0,C. WilliamsChi ,QB,9.36,QB,17.92,QB,D. PrescottDal 
-1,J. ChaseCin ,WR,7.5,WR,22.0,WR,C. LambDal 
-2,C. OlaveNO ,WR,12.8,WR,8.3,WR,B. AiyukSF 
-3,S. BarkleyPhi ,RB,17.6,RB,8.0,RB,J. MixonHou 
-4,J. TaylorInd ,RB,18.5,RB,17.0,RB,R. StevensonNE 
-5,T. KelceKC ,TE,1.6,TE,3.3,TE,S. LaPortaDet 
-6,K. ColemanBuf ,WR,0.0,W/R/T,4.9,WR,G. PickensPit 
-7,M. NabersNYG ,WR,31.7,W/R/T,14.5,RB,D. SingletaryNYG 
-8,Los AngelesLAC ,DEF,11.0,DEF,1.0,DEF,DallasDal 
+0,C. Williams,QB,9.36,QB,17.92,QB,D. Prescott
+1,J. Chase,WR,7.5,WR,22.0,WR,C. Lamb
+2,C. Olave,WR,12.8,WR,8.3,WR,B. Aiyuk
+3,S. Barkley,RB,17.6,RB,8.0,RB,J. Mixon
+4,J. Taylor,RB,18.5,RB,17.0,RB,R. Stevenson
+5,T. Kelce,TE,1.6,TE,3.3,TE,S. LaPorta
+6,K. Coleman,WR,0.0,W/R/T,4.9,WR,G. Pickens
+7,M. Nabers,WR,31.7,W/R/T,14.5,RB,D. Singletary
+8,Los Angeles,DEF,11.0,DEF,1.0,DEF,Dallas
 9,nan,,110.06,Total,96.92,,nan
-10,J. McLaughlinDen ,RB,0.6,BN,13.78,QB,J. GoffDet 
-11,X. LegetteCar ,WR,0.0,BN,0.0,RB,J. BrooksCar 
-12,R. OdunzeChi ,WR,5.3,BN,6.7,TE,C. KmetChi 
-13,A. RodgersNYJ ,QB,15.14,BN,12.3,WR,J. JeudyCle 
-14,R. DowdleDal ,RB,9.9,BN,3.6,WR,B. CooksDal 
-15,L. McCaffreyWas ,WR,0.0,BN,6.1,RB,A. MattisonLV 
-16,T. SermonInd ,RB,1.7,BN,13.3,WR,J. ReynoldsDen 
-17,ChicagoChi ,DEF,6.0,BN,1.9,WR,D. HopkinsTen 
+10,J. McLaughlin,RB,0.6,BN,13.78,QB,J. Goff
+11,X. Legette,WR,0.0,BN,0.0,RB,J. Brooks
+12,R. Odunze,WR,5.3,BN,6.7,TE,C. Kmet
+13,A. Rodgers,QB,15.14,BN,12.3,WR,J. Jeudy
+14,R. Dowdle,RB,9.9,BN,3.6,WR,B. Cooks
+15,L. McCaffrey,WR,0.0,BN,6.1,RB,A. Mattison
+16,T. Sermon,RB,1.7,BN,13.3,WR,J. Reynolds
+17,Chicago,DEF,6.0,BN,1.9,WR,D. Hopkins
 18,nan,,38.64,Total,57.68,,nan

--- a/matchup_data/week2/matchup_4.csv
+++ b/matchup_data/week2/matchup_4.csv
@@ -1,21 +1,21 @@
 ,A Nu Start,Position,Fan Pts,Roster Pos,Fan Pts.1,Position.1,Gales
-0,K. MurrayAri ,QB,31.54,QB,14.3,QB,C. StroudHou 
-1,M. Harrison Jr.Ari ,WR,35.0,WR,29.0,WR,D. AdamsLV 
-2,B. Thomas Jr.Jax ,WR,11.4,WR,2.3,WR,T. DellHou 
-3,T. PollardTen ,RB,15.2,RB,16.2,RB,B. RobinsonAtl 
-4,E. ElliottDal ,RB,5.2,RB,31.5,RB,J. CookBuf 
-5,T. McBrideAri ,TE,18.7,TE,7.3,TE,D. KincaidBuf 
-6,T. JohnsonLAR ,WR,4.0,W/R/T,11.5,RB,A. EkelerWas 
-7,J. HillBal ,RB,5.2,W/R/T,3.6,WR,C. SuttonDen 
-8,IndianapolisInd ,DEF,3.0,DEF,13.0,DEF,PittsburghPit 
+0,K. Murray,QB,31.54,QB,14.3,QB,C. Stroud
+1,M. Harrison Jr.,WR,35.0,WR,29.0,WR,D. Adams
+2,B. Thomas Jr.,WR,11.4,WR,2.3,WR,T. Dell
+3,T. Pollard,RB,15.2,RB,16.2,RB,B. Robinson
+4,E. Elliott,RB,5.2,RB,31.5,RB,J. Cook
+5,T. McBride,TE,18.7,TE,7.3,TE,D. Kincaid
+6,T. Johnson,WR,4.0,W/R/T,11.5,RB,A. Ekeler
+7,J. Hill,RB,5.2,W/R/T,3.6,WR,C. Sutton
+8,Indianapolis,DEF,3.0,DEF,13.0,DEF,Pittsburgh
 9,nan,,129.24,Total,128.7,,nan
-10,A. BrownPhi ,WR,0.0,BN,4.10,TE,D. SchultzHou 
-11,R. DoubsGB ,WR,9.2,BN,2.80,RB,B. CorumLAR 
-12,C. BrownCin ,RB,3.1,BN,4.00,WR,A. MitchellInd 
-13,Q. JohnstonLAC ,WR,22.1,BN,0.00,RB,K. VidalLAC 
-14,T. ChandlerMin ,RB,8.2,BN,20.54,QB,K. CousinsAtl 
-15,R. BatemanBal ,WR,7.0,BN,4.20,WR,J. WhittingtonLAR 
-16,B. NixDen ,QB,10.34,BN,1.30,RB,S. PerineKC 
-17,D. VeleDen ,WR,0.0,BN,3.10,WR,G. DortchAri 
-18,K. MillerNO ,RB,0.0,IR,â,(Empty),(Empty)
+10,A. Brown,WR,0.0,BN,4.10,TE,D. Schultz
+11,R. Doubs,WR,9.2,BN,2.80,RB,B. Corum
+12,C. Brown,RB,3.1,BN,4.00,WR,A. Mitchell
+13,Q. Johnston,WR,22.1,BN,0.00,RB,K. Vidal
+14,T. Chandler,RB,8.2,BN,20.54,QB,K. Cousins
+15,R. Bateman,WR,7.0,BN,4.20,WR,J. Whittington
+16,B. Nix,QB,10.34,BN,1.30,RB,S. Perine
+17,D. Vele,WR,0.0,BN,3.10,WR,G. Dortch
+18,K. Miller,RB,0.0,IR,â,(Empty),(Empty)
 19,nan,,59.94,Total,40.04,,nan

--- a/matchup_data/week2/matchup_5.csv
+++ b/matchup_data/week2/matchup_5.csv
@@ -1,21 +1,21 @@
 ,Flavortown,Position,Fan Pts,Roster Pos,Fan Pts.1,Position.1,Njigba’s in Paris
-0,P. MahomesKC ,QB,17.94,QB,12.86,QB,A. RichardsonInd 
-1,Z. FlowersBal ,WR,22.1,WR,17.4,WR,D. LondonAtl 
-2,D. MooreChi ,WR,11.3,WR,7.2,WR,M. EvansTB 
-3,A. KamaraNO ,RB,50.0,RB,5.7,RB,Z. MossCin 
-4,J. FordCle ,RB,7.4,RB,26.1,RB,J. DobbinsLAC 
-5,C. ParkinsonLAR ,TE,2.2,TE,4.6,TE,I. LikelyBal 
-6,D. SmithPhi ,WR,20.6,W/R/T,5.1,WR,M. Pittman Jr.Ind 
-7,J. ConnerAri ,RB,22.4,W/R/T,26.7,,J. Smith
-8,SeattleSea ,DEF,6.0,DEF,18.0,DEF,BuffaloBuf 
+0,P. Mahomes,QB,17.94,QB,12.86,QB,A. Richardson
+1,Z. Flowers,WR,22.1,WR,17.4,WR,D. London
+2,D. Moore,WR,11.3,WR,7.2,WR,M. Evans
+3,A. Kamara,RB,50.0,RB,5.7,RB,Z. Moss
+4,J. Ford,RB,7.4,RB,26.1,RB,J. Dobbins
+5,C. Parkinson,TE,2.2,TE,4.6,TE,I. Likely
+6,D. Smith,WR,20.6,W/R/T,5.1,WR,M. Pittman Jr.
+7,J. Conner,RB,22.4,W/R/T,26.7,,J. Smith
+8,Seattle,DEF,6.0,DEF,18.0,DEF,Buffalo
 9,nan,,159.94,Total,123.66,,nan
-10,K. Walker IIISea ,RB,0.0,BN,11.60,RB,C. HubbardCar 
-11,C. McCaffreySF ,RB,0.0,BN,9.80,WR,W. RobinsonNYG 
-12,D. NjokuCle ,TE,0.0,BN,2.90,"QB,TE",T. HillNO 
-13,M. CorleyNYJ ,WR,1.4,BN,0.00,RB,R. MostertMia 
-14,C. KirkJax ,WR,0.9,BN,6.64,QB,M. StaffordLAR 
-15,R. ShaheedNO ,WR,23.9,BN,6.90,WR,J. MeyersLV 
-16,B. IrvingTB ,RB,2.2,BN,7.30,WR,G. DavisJax 
-17,J. SmithMia ,TE,11.3,BN,0.00,WR,D. DouglasNE 
-18,T. HockensonMin ,TE,0.0,IR,â,(Empty),(Empty)
+10,K. Walker III,RB,0.0,BN,11.60,RB,C. Hubbard
+11,C. McCaffrey,RB,0.0,BN,9.80,WR,W. Robinson
+12,D. Njoku,TE,0.0,BN,2.90,"QB,TE",T. Hill
+13,M. Corley,WR,1.4,BN,0.00,RB,R. Mostert
+14,C. Kirk,WR,0.9,BN,6.64,QB,M. Stafford
+15,R. Shaheed,WR,23.9,BN,6.90,WR,J. Meyers
+16,B. Irving,RB,2.2,BN,7.30,WR,G. Davis
+17,J. Smith,TE,11.3,BN,0.00,WR,D. Douglas
+18,T. Hockenson,TE,0.0,IR,â,(Empty),(Empty)
 19,nan,,39.7,Total,45.14,,nan

--- a/matchup_data/week2/matchup_6.csv
+++ b/matchup_data/week2/matchup_6.csv
@@ -1,20 +1,20 @@
 ,Liver King III,Position,Fan Pts,Roster Pos,Fan Pts.1,Position.1,Kamalas Hairy Clit
-0,L. JacksonBal ,QB,17.38,QB,24.82,QB,J. HurtsPhi 
-1,J. JeffersonMin ,WR,29.3,WR,30.7,WR,C. GodwinTB 
-2,A. CooperCle ,WR,4.1,WR,4.2,WR,X. WorthyKC 
-3,B. HallNYJ ,RB,24.4,RB,16.1,RB,J. JacobsGB 
-4,B. Robinson Jr.Was ,RB,17.6,RB,17.0,RB,D. MontgomeryDet 
-5,K. PittsAtl ,TE,5.0,TE,6.8,TE,D. GoedertPhi 
-6,S. DiggsHou ,WR,7.7,W/R/T,5.1,RB,T. SpearsTen 
-7,J. ReedGB ,WR,6.6,W/R/T,1.6,WR,J. DotsonPhi 
-8,HoustonHou ,DEF,15.0,DEF,7.0,DEF,BaltimoreBal 
+0,L. Jackson,QB,17.38,QB,24.82,QB,J. Hurts
+1,J. Jefferson,WR,29.3,WR,30.7,WR,C. Godwin
+2,A. Cooper,WR,4.1,WR,4.2,WR,X. Worthy
+3,B. Hall,RB,24.4,RB,16.1,RB,J. Jacobs
+4,B. Robinson Jr.,RB,17.6,RB,17.0,RB,D. Montgomery
+5,K. Pitts,TE,5.0,TE,6.8,TE,D. Goedert
+6,S. Diggs,WR,7.7,W/R/T,5.1,RB,T. Spears
+7,J. Reed,WR,6.6,W/R/T,1.6,WR,J. Dotson
+8,Houston,DEF,15.0,DEF,7.0,DEF,Baltimore
 9,nan,,127.08,Total,113.32,,nan
-10,N. HarrisPit ,RB,8.4,BN,0.0,WR,K. AllenChi 
-11,T. BensonAri ,RB,2.7,BN,0.0,WR,J. AddisonMin 
-12,J. DanielsWas ,QB,13.44,BN,13.3,QB,T. LawrenceJax 
-13,A. ThielenCar ,WR,4.0,BN,7.9,TE,P. FreiermuthPit 
-14,T. LockettSea ,WR,3.5,BN,0.0,WR,J. DownsInd 
-15,R. DavisBuf ,RB,3.8,BN,8.7,RB,K. HerbertChi 
-16,B. SinnottWas ,TE,0.0,BN,23.88,QB,G. SmithSea 
-17,R. WilsonPit ,WR,0.0,BN,0.0,DEF,MiamiMia 
+10,N. Harris,RB,8.4,BN,0.0,WR,K. Allen
+11,T. Benson,RB,2.7,BN,0.0,WR,J. Addison
+12,J. Daniels,QB,13.44,BN,13.3,QB,T. Lawrence
+13,A. Thielen,WR,4.0,BN,7.9,TE,P. Freiermuth
+14,T. Lockett,WR,3.5,BN,0.0,WR,J. Downs
+15,R. Davis,RB,3.8,BN,8.7,RB,K. Herbert
+16,B. Sinnott,TE,0.0,BN,23.88,QB,G. Smith
+17,R. Wilson,WR,0.0,BN,0.0,DEF,Miami
 18,nan,,35.84,Total,53.78,,nan


### PR DESCRIPTION
The HTML has the team abbreviation at the end of the player names, I added a function to clip that part before being stored into the csv